### PR TITLE
Catch unmatched deposits

### DIFF
--- a/src/whatsthedamage/row_enrichment.py
+++ b/src/whatsthedamage/row_enrichment.py
@@ -13,7 +13,7 @@ class RowEnrichment:
         self.rows = rows
         self.pattern_sets = pattern_sets
         self.categorized: dict[str, list['CsvRow']] = {"other": []}
-        self.sum_attribute = None
+        self.sum_attribute = ""
 
     def set_sum_attribute(self, sum_attribute: str) -> None:
         """

--- a/src/whatsthedamage/row_enrichment.py
+++ b/src/whatsthedamage/row_enrichment.py
@@ -13,7 +13,15 @@ class RowEnrichment:
         self.rows = rows
         self.pattern_sets = pattern_sets
         self.categorized: dict[str, list['CsvRow']] = {"other": []}
-        self.initialize()
+        self.sum_attribute = None
+
+    def set_sum_attribute(self, sum_attribute: str) -> None:
+        """
+        Set the sum attribute.
+
+        :param sum_attribute: str: The name of the attribute to sum.
+        """
+        self.sum_attribute = sum_attribute
 
     def initialize(self) -> None:
         """
@@ -60,6 +68,11 @@ class RowEnrichment:
                     break
 
             if not matched:
+                # catch any not matched possible deposits
+                sum_value = getattr(row, self.sum_attribute, None)
+                if sum_value is not None and int(sum_value) > 0:
+                    setattr(row, 'category', 'deposits')
+                    continue
                 setattr(row, 'category', 'other')  # Default to 'other' if no match
 
     def categorize_by_attribute(self, attribute_name: str) -> dict[str, list['CsvRow']]:

--- a/src/whatsthedamage/whatsthedamage.py
+++ b/src/whatsthedamage/whatsthedamage.py
@@ -112,6 +112,8 @@ def process_rows(
         for set_name, set_rows in filtered_set.items():
             # Add attribute 'category' based on a specified other attribute matching against a set of patterns
             enricher = RowEnrichment(set_rows, cfg_pattern_sets)
+            enricher.set_sum_attribute(sum_attribute)
+            enricher.initialize()
 
             # Categorize rows by specificed attribute
             set_rows_dict = enricher.categorize_by_attribute(args.category)

--- a/tests/test_row_enrichment.py
+++ b/tests/test_row_enrichment.py
@@ -22,6 +22,7 @@ def setup_data():
 
 def test_initialize(setup_data):
     _, _, row_enrichment = setup_data
+    row_enrichment.initialize()
     assert "category1" in row_enrichment.categorized
     assert "category2" in row_enrichment.categorized
     assert "other" in row_enrichment.categorized


### PR DESCRIPTION
Some transactions categorized as 'other' may contain amounts with positive values (ie. > 0). This feature categorizes them as 'deposits'.