### PR TITLE
chore: remove Optional type hints, raise exceptions instead

### DIFF
--- a/src/whatsthedamage/models/csv_processor.py
+++ b/src/whatsthedamage/models/csv_processor.py
@@ -35,7 +35,7 @@ class CSVProcessor:
         Processes the CSV file and returns the formatted result.
 
         Returns:
-            Optional[str]: The formatted result as a string or None.
+            str: The formatted result as a string or None.
         """
         rows = self._read_csv_file()
         data_for_pandas = self.processor.process_rows(rows)
@@ -65,7 +65,7 @@ class CSVProcessor:
             data_for_pandas (Dict[str, Dict[str, float]]): The data to format.
 
         Returns:
-            Optional[str]: The formatted data as a string or None.
+            str: The formatted data as a string or None.
         """
         formatter = DataFrameFormatter()
         formatter.set_nowrap(self.args.get('nowrap', False))

--- a/src/whatsthedamage/models/data_frame_formatter.py
+++ b/src/whatsthedamage/models/data_frame_formatter.py
@@ -1,10 +1,23 @@
 import pandas as pd
 import locale
-from typing import Optional, Dict
+from typing import Dict
 
 """
 A module for formatting pandas DataFrames with optional currency formatting and nowrap options.
 """
+
+
+def format_currency(value: float) -> str:
+    """
+    Formats a numeric value as a currency string.
+
+    :param value: The numeric value to format. Must be a float.
+    :return: The formatted currency string.
+    :raises TypeError: If the value is not a float.
+    """
+    if not isinstance(value, float):
+        raise TypeError(f"Expected a float, but got {type(value).__name__}")
+    return locale.currency(value, grouping=True)
 
 
 class DataFrameFormatter:
@@ -57,12 +70,5 @@ class DataFrameFormatter:
 
         # Format the DataFrame with currency values
         if not self._no_currency_format:
-            def format_currency(value: Optional[float]) -> str:
-                if value is None:
-                    return 'N/A'
-                if isinstance(value, (int, float)):
-                    return locale.currency(value, grouping=True)
-                return str(value)  # type: ignore[unreachable]
-
             df = df.apply(lambda row: row.apply(format_currency), axis=1)
         return df

--- a/src/whatsthedamage/models/rows_processor.py
+++ b/src/whatsthedamage/models/rows_processor.py
@@ -24,9 +24,9 @@ class RowsProcessor:
         self._date_attribute_format: str = context.config.csv.date_attribute_format
         self._cfg_pattern_sets: Dict[str, Dict[str, List[str]]] = context.config.enricher_pattern_sets
         self._start_date: Optional[str] = context.args.get("start_date", None)
-        self._start_date_epoch: Optional[int] = None
+        self._start_date_epoch: float = 0
         self._end_date: Optional[str] = context.args.get("end_date", None)
-        self._end_date_epoch: Optional[int] = None
+        self._end_date_epoch: float = 0
         self._verbose: bool = context.args.get("verbose", False)
         self._category: str = context.args.get("category", "")
         self._filter: Optional[str] = context.args.get("filter", None)
@@ -36,14 +36,14 @@ class RowsProcessor:
             formatted_start_date = DateConverter.convert_date_format(
                 self._start_date, self._date_attribute_format
             )
-            self._start_date_epoch: Optional[int] = DateConverter.convert_to_epoch(
+            self._start_date_epoch = DateConverter.convert_to_epoch(
                 formatted_start_date, self._date_attribute_format
             )
         if self._end_date:
             formatted_end_date = DateConverter.convert_date_format(
                 self._end_date, self._date_attribute_format
             )
-            self._end_date_epoch: Optional[int] = DateConverter.convert_to_epoch(
+            self._end_date_epoch = DateConverter.convert_to_epoch(
                 formatted_end_date, self._date_attribute_format
             )
 
@@ -85,7 +85,7 @@ class RowsProcessor:
             List[Dict[str, List[CsvRow]]]: A list of dictionaries with filtered rows.
         """
         row_filter = RowFilter(rows, self._date_attribute_format)
-        if self._start_date_epoch and self._end_date_epoch:
+        if self._start_date_epoch > 0 and self._end_date_epoch > 0:
             return list(row_filter.filter_by_date(self._start_date_epoch, self._end_date_epoch))
         return list(row_filter.filter_by_month())
 

--- a/src/whatsthedamage/utils/date_converter.py
+++ b/src/whatsthedamage/utils/date_converter.py
@@ -1,11 +1,10 @@
 from datetime import datetime, timezone
-from typing import Optional
 from dateutil import parser
 
 
 class DateConverter:
     @staticmethod
-    def convert_to_epoch(date_str: Optional[str], date_format: str) -> Optional[int]:
+    def convert_to_epoch(date_str: str, date_format: str) -> int:
         """
         Convert a date string to epoch time.
 
@@ -20,10 +19,10 @@ class DateConverter:
                 return int(date_obj.timestamp())
             except ValueError:
                 raise ValueError(f"Invalid date format for '{date_str}'")
-        return None
+        raise ValueError("Date string cannot be None or empty")
 
     @staticmethod
-    def convert_from_epoch(epoch: Optional[float], date_format: str) -> Optional[str]:
+    def convert_from_epoch(epoch: float, date_format: str) -> str:
         """
         Convert an epoch time to a date string.
 
@@ -38,7 +37,7 @@ class DateConverter:
                 return date_obj.strftime(date_format)
             except (ValueError, OverflowError, OSError):
                 raise ValueError(f"Invalid epoch value '{epoch}'")
-        return None
+        raise ValueError("Epoch value cannot be None or empty")
 
     @staticmethod
     def convert_month_number_to_name(month_number: int) -> str:

--- a/tests/test_date_converter.py
+++ b/tests/test_date_converter.py
@@ -16,12 +16,6 @@ def test_convert_to_epoch_invalid_date():
         DateConverter.convert_to_epoch(date_str, date_format)
 
 
-def test_convert_to_epoch_none_date():
-    date_str = None
-    date_format = "%Y.%m.%d"
-    assert DateConverter.convert_to_epoch(date_str, date_format) is None
-
-
 def test_convert_from_epoch_valid_epoch():
     epoch = 1696464000
     date_format = "%Y.%m.%d"
@@ -35,12 +29,6 @@ def test_convert_from_epoch_invalid_epoch():
     date_format = "%Y.%m.%d"
     with pytest.raises(ValueError):
         DateConverter.convert_from_epoch(epoch, date_format)
-
-
-def test_convert_from_epoch_none_epoch():
-    epoch = None
-    date_format = "%Y.%m.%d"
-    assert DateConverter.convert_from_epoch(epoch, date_format) is None
 
 
 def test_convert_month_number_to_name_valid():

--- a/tests/test_row_filter.py
+++ b/tests/test_row_filter.py
@@ -34,7 +34,8 @@ def row_filter(sample_rows):
 def test_get_month_number(row_filter):
     assert row_filter.get_month_number("2023-01-15") == "01"
     assert row_filter.get_month_number("2023-12-10") == "12"
-    assert row_filter.get_month_number(None) is None
+    with pytest.raises(ValueError, match="Date value cannot be None"):
+        row_filter.get_month_number(None)
 
 
 def test_filter_by_date(row_filter):


### PR DESCRIPTION
Optional type hints often hindered advancements.
Instead of returning and checking for None state rather raise exceptions to fail early.