### PR TITLE
Frontend should use machine learning model by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Should you want to check your regular expressions then you can use a handy onlin
 
 Note: Regexp values are not stored as raw strings, so watch out for possible backslashes. For more information, see [What exactly is a raw string regex and how can you use it?](https://stackoverflow.com/questions/12871066/what-exactly-is-a-raw-string-regex-and-how-can-you-use-it).
 
-### Transaction categories
+## Transaction categories
 
 A list of frequent transaction categories a bank account may have.
 
@@ -185,14 +185,6 @@ poedit locale/en/LC_MESSAGES/messages.po
 ```bash
 msgfmt locale/en/LC_MESSAGES/messages.po -o locale/en/LC_MESSAGES/messages.mo
 ```
-
-## Bugs, TODO
-
-- Fix time skew issues:
-  - The 'könyvelés dátuma' attribute is most likely in local time but converting into epoch assumes UTC. Without timezone information we can only guess.
-  - The arguments `--start-date` and `--end-date` assumes hours, minutes and seconds to be 00:00:00 and not 23:59:59.
-- Migrate joblib to skops.io or ONNX.
-- A docker image is planned for the future to make it easier to start using it.
 
 ## Contributing
 

--- a/src/whatsthedamage/config/config.py
+++ b/src/whatsthedamage/config/config.py
@@ -28,10 +28,16 @@ class AppArgs(TypedDict):
 
 
 class CsvConfig(BaseModel):
-    dialect: str
-    delimiter: str
-    date_attribute_format: str
-    attribute_mapping: Dict[str, str]
+    dialect: str = Field(default="excel-tab")
+    delimiter: str = Field(default="\t")
+    date_attribute_format: str = Field(default="%Y.%m.%d")
+    attribute_mapping: Dict[str, str] = Field(default_factory=lambda: {
+        "date": "könyvelés dátuma",
+        "type": "típus",
+        "partner": "partner elnevezése",
+        "amount": "összeg",
+        "currency": "összeg devizaneme"
+    })
 
 
 class CategoryDefinition(BaseModel):
@@ -85,13 +91,19 @@ class AppContext:
         self.args: AppArgs = args
 
 
-def load_config(config_path: str) -> AppConfig:
+def load_config(config_path: str | None) -> AppConfig:
     """
     Load the application configuration from a YAML file.
 
     :param config_path: Path to the YAML configuration file.
     :return: An AppConfig object.
     """
+    if not config_path or config_path == "":
+        print("Warning: No configuration file provided, using default settings.", file=sys.stderr)
+        return AppConfig(
+            csv=CsvConfig(),
+            enricher_pattern_sets=EnricherPatternSets()
+        )
     try:
         with open(config_path, 'r', encoding='utf-8') as file:
             config_data = yaml.safe_load(file)

--- a/src/whatsthedamage/controllers/cli.py
+++ b/src/whatsthedamage/controllers/cli.py
@@ -12,7 +12,7 @@ def parse_arguments() -> AppArgs:
     parser.add_argument('--end-date', type=str, help='End date (e.g. YYYY.MM.DD.)')
     parser.add_argument('--verbose', '-v', action='store_true', help='Print categorized rows for troubleshooting.')
     parser.add_argument('--version', action='version', version='What\'s the Damage', help='Show the version of the program.')  # noqa: E501
-    parser.add_argument('--config', '-c', type=str, default='config.yml.default', help='Path to the configuration file. (default: config.yml.default)')  # noqa: E501
+    parser.add_argument('--config', '-c', type=str, help='Path to the configuration file.')
     parser.add_argument('--category', type=str, default='category', help='The attribute to categorize by. (default: category)')  # noqa: E501
     parser.add_argument('--no-currency-format', action='store_true', help='Disable currency formatting. Useful for importing the data into a spreadsheet.')  # noqa: E501
     parser.add_argument('--output', '-o', type=str, help='Save the result into a CSV file with the specified filename.')  # noqa: E501

--- a/src/whatsthedamage/controllers/routes.py
+++ b/src/whatsthedamage/controllers/routes.py
@@ -79,10 +79,13 @@ def process() -> Response:
             config_path = safe_join(upload_folder, config)  # type: ignore
             form.config.data.save(config_path)
         else:
-            config_path = safe_join(os.getcwd(), current_app.config['DEFAULT_WHATSTHEDAMAGE_CONFIG'])  # type: ignore
-            if config_path and not os.path.exists(config_path):
-                flash('Default config file not found. Please upload one.', 'danger')
-                return make_response(redirect(url_for('main.index')))
+            if not form.ml.data:
+                config_path = safe_join(
+                    os.getcwd(), current_app.config['DEFAULT_WHATSTHEDAMAGE_CONFIG']   # type: ignore
+                )
+                if config_path and not os.path.exists(config_path):
+                    flash('Default config file not found. Please upload one.', 'danger')
+                    return make_response(redirect(url_for('main.index')))
 
         if not allowed_file(filename_path) or (config_path and not allowed_file(config_path)):
             flash('Invalid file type. Only CSV and YAML files are allowed.', 'danger')
@@ -102,7 +105,7 @@ def process() -> Response:
             filter=form.filter.data,
             lang=session.get('lang', get_default_language()),
             training_data=False,
-            ml=False
+            ml=form.ml.data,
         )
 
         # Store form data in session

--- a/src/whatsthedamage/controllers/whatsthedamage.py
+++ b/src/whatsthedamage/controllers/whatsthedamage.py
@@ -58,7 +58,7 @@ def main(args: AppArgs) -> str:
     set_locale(args['lang'])
 
     # Load the configuration file
-    config = load_config(str(args['config']))
+    config = load_config(args['config'])
 
     # Create AppContext
     context = AppContext(config, args)

--- a/src/whatsthedamage/models/machine_learning.py
+++ b/src/whatsthedamage/models/machine_learning.py
@@ -91,13 +91,29 @@ class MLConfig(BaseModel):
     max_depth: Union[int, None] = None
     test_size: float = 0.2
     model_version: str = "v5alpha_en"
-    model_path: str = "src/whatsthedamage/static/model-{short}-{ver}.joblib".format(
-        short=classifier_short_name, ver=model_version
-    )
-    manifest_path: str = "src/whatsthedamage/static/model-{short}-{ver}.manifest.json".format(
-        short=classifier_short_name, ver=model_version
-    )
     feature_columns: List[str] = ["type", "partner", "currency", "amount"]
+
+    @property
+    def model_path(self) -> str:
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        static_dir = os.path.join(base_dir, "..", "static")
+        return os.path.abspath(
+            os.path.join(
+                static_dir,
+                f"model-{self.classifier_short_name}-{self.model_version}.joblib"
+            )
+        )
+
+    @property
+    def manifest_path(self) -> str:
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        static_dir = os.path.join(base_dir, "..", "static")
+        return os.path.abspath(
+            os.path.join(
+                static_dir,
+                f"model-{self.classifier_short_name}-{self.model_version}.manifest.json"
+            )
+        )
 
 
 class TrainingData:

--- a/src/whatsthedamage/view/forms.py
+++ b/src/whatsthedamage/view/forms.py
@@ -11,3 +11,4 @@ class UploadForm(FlaskForm):  # type: ignore
     filter = StringField()
     verbose = BooleanField()
     no_currency_format = BooleanField()
+    ml = BooleanField(default=True)

--- a/src/whatsthedamage/view/templates/index.html
+++ b/src/whatsthedamage/view/templates/index.html
@@ -98,6 +98,16 @@
                                 <label for="no_currency_format" class="form-check-label">{{ _('No currency formatting') }}</label>
                                 <div id="currencyHelp" class="form-text">{{ _('Select this option to exclude currency symbols in the exported CSV. You can format the cells in your spreadsheet application instead.') }}</div>
                             </div>
+                            <div class="mb-3 form-check">
+                                {{ form.ml(class="form-check-input", id="ml") }}
+                                <label for="ml" class="form-check-label">
+                                    {{ _('Use Machine Learning model for categorization') }}
+                                    <span class="text-muted">({{ config.ML_MODEL }})</span>
+                                </label>
+                                <div id="mlHelp" class="form-text">
+                                    {{ _('Uncheck to use regular expressions instead of the ML model.') }}
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,7 @@ def test_load_config_valid_file(tmp_path):
     config_file = tmp_path / "config.yml"
     config_file.write_text(yaml.dump(config_data))
 
-    config = load_config(str(config_file))
+    config = load_config(config_file)
     assert isinstance(config, AppConfig)
     assert config.csv.dialect == "excel"
 
@@ -32,29 +32,7 @@ def test_load_config_invalid_yaml(tmp_path):
     config_file.write_text(invalid_yaml)
 
     with pytest.raises(SystemExit):
-        load_config(str(config_file))
-
-
-def test_load_config_validation_error(tmp_path):
-    invalid_config_data = {
-        "csv": {
-            "dialect": "excel",
-            "delimiter": ",",
-            "date_attribute_format": "%Y-%m-%d"
-            # Missing attribute_mapping
-        },
-        "enricher_pattern_sets": {
-            "type": {
-                "subpattern1": ["value1", "value2"]
-            },
-            "partner": {}
-        }
-    }
-    config_file = tmp_path / "config.yml"
-    config_file.write_text(yaml.dump(invalid_config_data))
-
-    with pytest.raises(SystemExit):
-        load_config(str(config_file))
+        load_config(config_file)
 
 
 def test_load_config_file_not_found():


### PR DESCRIPTION
Creating and maintaining dozens of regular expressions will probably frighten casual users.
Provide a pre-built machine learning model to categorize transactions for having better out of the box experience.
You can opt-out.